### PR TITLE
fixing variadic parameter

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 .idea
+vendor

--- a/mock_v9/redis_cache_v2_test.go
+++ b/mock_v9/redis_cache_v2_test.go
@@ -33,7 +33,7 @@ var _ = Describe("Redis Cache V2", func() {
 
 		It("should successfully call MGet", func() {
 
-			mockRedis.EXPECT().MGet(gomock.Any(), gomock.Any(), gomock.Any()).DoAndReturn(func(context context.Context, cacheKey string, deleteKey string) *redis.SliceCmd {
+			mockRedis.EXPECT().MGet(gomock.Any(), gomock.Any()).DoAndReturn(func(context context.Context, args ...string) *redis.SliceCmd {
 				defer GinkgoRecover()
 				buf := make([]byte, 8)
 				binary.BigEndian.PutUint64(buf, uint64(100))


### PR DESCRIPTION
Fix Variadic parameter when EXPECT method.
refer from this sample code in uber/mock
https://github.com/golang/mock/blob/main/mockgen/internal/tests/generated_identifier_conflict/bugreport_test.go
![image](https://github.com/PhilAndrew/mockgenredisv9/assets/766900/18529df1-7fcb-4406-9336-abda4b79e6a0)
Hope this PR will solve your problem.
Enjoy!
